### PR TITLE
Add Flask web interface for managing attachments

### DIFF
--- a/readme.MD
+++ b/readme.MD
@@ -22,3 +22,16 @@ python mailstor.py
 
 The script will create folders `mailstor1`, `mailstor2`, etc., each
 containing attachments for up to 500 emails from your inbox.
+
+## Web Interface
+
+A simple Flask app is provided to browse the downloaded attachments and
+optionally download or delete them.
+
+Run the app with:
+
+```bash
+python webapp.py
+```
+
+The interface will be available at `http://127.0.0.1:5000/`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 python-dotenv
+Flask

--- a/webapp.py
+++ b/webapp.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List
+
+from flask import Flask, abort, redirect, render_template_string, send_from_directory, url_for
+
+app = Flask(__name__)
+
+BASE_DIR = Path(__file__).resolve().parent
+ATTACHMENT_PREFIX = "mailstor"
+
+
+def _list_files() -> List[str]:
+    files: List[str] = []
+    for directory in sorted(BASE_DIR.iterdir()):
+        if directory.is_dir() and directory.name.startswith(ATTACHMENT_PREFIX):
+            for file in sorted(directory.iterdir()):
+                if file.is_file():
+                    rel_path = f"{directory.name}/{file.name}"
+                    files.append(rel_path)
+    return files
+
+
+@app.route("/")
+def index():
+    files = _list_files()
+    return render_template_string(
+        """
+        <!doctype html>
+        <title>Files</title>
+        <h1>Your Files</h1>
+        <ul>
+        {% for f in files %}
+          <li>{{ f }} - <a href="{{ url_for('download_file', path=f) }}">download</a> | <a href="{{ url_for('delete_file', path=f) }}">delete</a></li>
+        {% else %}
+          <li>No files found.</li>
+        {% endfor %}
+        </ul>
+        """,
+        files=files,
+    )
+
+
+@app.route("/download/<path:path>")
+def download_file(path: str):
+    target = (BASE_DIR / path).resolve()
+    if not target.is_file() or BASE_DIR.resolve() not in target.parents:
+        abort(404)
+    return send_from_directory(target.parent, target.name, as_attachment=True)
+
+
+@app.route("/delete/<path:path>")
+def delete_file(path: str):
+    target = (BASE_DIR / path).resolve()
+    if (
+        not target.is_file()
+        or BASE_DIR.resolve() not in target.parents
+        or not target.parent.name.startswith(ATTACHMENT_PREFIX)
+    ):
+        abort(404)
+    target.unlink()
+    return redirect(url_for("index"))
+
+
+if __name__ == "__main__":
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- Add Flask-powered web server for listing, downloading, and deleting stored attachments
- Document web interface usage in README
- Add Flask dependency

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile mailstor.py webapp.py`
- `python webapp.py` (server startup)


------
https://chatgpt.com/codex/tasks/task_e_68b3700ceeb4832fa68c2394dd8d9ac8