### PR TITLE
Ensure attachment folders are created alongside script

### DIFF
--- a/readme.MD
+++ b/readme.MD
@@ -1,8 +1,9 @@
 # MailStor
 
-A simple utility that uses IMAP to download e-mail attachments and store
-them in batches of 500 messages per folder. Folders are named
-`mailstor1`, `mailstor2`, and so on.
+A simple utility that uses IMAP to archive e‑mail attachments on the
+server itself. Attachments from messages in the INBOX are uploaded as
+separate messages to server-side folders named `mailstor1`, `mailstor2`
+and so on, with each folder holding attachments from up to 500 e-mails.
 
 ## Setup
 
@@ -20,20 +21,6 @@ pip install -r requirements.txt
 python mailstor.py
 ```
 
-The script will create folders `mailstor1`, `mailstor2`, etc., each
-containing attachments for up to 500 emails from your inbox. Folders are
-created alongside `mailstor.py`, regardless of the working directory from
-which the script is executed.
+The script will create folders `mailstor1`, `mailstor2`, etc. **on the
+IMAP server** and store attachments there as individual messages.
 
-## Web Interface
-
-A simple Flask app is provided to browse the downloaded attachments and
-optionally download or delete them.
-
-Run the app with:
-
-```bash
-python webapp.py
-```
-
-The interface will be available at `http://127.0.0.1:5000/`.

--- a/readme.MD
+++ b/readme.MD
@@ -21,7 +21,9 @@ python mailstor.py
 ```
 
 The script will create folders `mailstor1`, `mailstor2`, etc., each
-containing attachments for up to 500 emails from your inbox.
+containing attachments for up to 500 emails from your inbox. Folders are
+created alongside `mailstor.py`, regardless of the working directory from
+which the script is executed.
 
 ## Web Interface
 


### PR DESCRIPTION
## Summary
- Save attachment folders relative to `mailstor.py` so downloads are consistently stored next to the script
- Clarify documentation about where attachment folders are created

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile mailstor.py webapp.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3755d313c832fbe33317d2fa58848